### PR TITLE
fix link redirection

### DIFF
--- a/companies.js
+++ b/companies.js
@@ -319,7 +319,7 @@ export const COMPANIES = [
         instagram: 'wellmarkbcbs',
         twitter: 'wellmarkbcbs',
         linkedin: 'wellmark',
-        careers: 'www.wellmark.com/careers',
+        careers: 'https://www.wellmark.com/careers',
         lat: '41.586258',
         lng: '-93.634036'
     },


### PR DESCRIPTION
couldn't get this to run locally on Windows 10, but tested with chrome web tools, seems to fix redirection. Without this it just tries to send to https://dsmtech.io/www.wellmark.com/careers and returns 404