### PR TITLE
feat: add target=_blank to links in page.tsx

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -134,7 +134,7 @@ let TableRow = (company) => {
         <SocialMedia {...company} />
       </td>
       <td className="px-6 py-4 whitespace-no-wrap text-right text-sm leading-5 font-medium min-w-[120px]">
-        <a href={company.careers} className="text-blue-600 hover:text-blue-900">
+        <a href={company.careers} className="text-blue-600 hover:text-blue-900" target="_blank" rel="noopener noreferrer">
           View Jobs
         </a>
       </td>


### PR DESCRIPTION
To improve user experience I added the target attribute and set it to "_blank" (as well as added the rel="noopener noreferrer" based on security best practices) . Links open in a new tab allowing the user to explore the job link resources without losing their current place on the site.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a simple UI-only change to link attributes with no impact on data handling or business logic.
> 
> **Overview**
> Updates the `View Jobs` careers link in `app/page.tsx` to open in a new tab via `target="_blank"`, and adds `rel="noopener noreferrer"` to follow security best practices.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 739c7c34fc8558270b2bd1c61b500af2f2a93509. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>739c7c3</u></sup><!-- /BUGBOT_STATUS -->