### PR TITLE
line 150 added ARIA landmark, role="main"

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -147,7 +147,7 @@ export default function HomePage() {
     <div className="flex flex-col px-8 mb-8">
       <div className="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
         <div className="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">
-          <div className="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
+          <div className="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg" role="main">
             <table className="min-w-full divide-y divide-gray-200">
               <thead>
                 <tr>


### PR DESCRIPTION
Trivial. Set one primary landmark to help screen reader users navigate the page efficiently.  In the case of this layout it would make sense to chose either an HTML5 `<main>` tag or an ARIA role="main" attribute.
To improve accessibility, I’ve added ARIA role="main" to the div on line 150 (page.tsx).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single ARIA attribute is added to improve screen-reader navigation and does not affect data flow or business logic.
> 
> **Overview**
> Adds an ARIA landmark by setting `role="main"` on the main content container in `app/page.tsx`, improving accessibility and screen-reader navigation without changing UI behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2f60e30a7049d0e6e9d629169340c1253598b9c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>c2f60e3</u></sup><!-- /BUGBOT_STATUS -->