### PR TITLE
Simplify dev/build on Bun-native primitives and add live reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,18 +7,22 @@ An end-to-end [Bun](https://bun.com) project with **zero runtime dependencies** 
 - `src/companies.ts` — the dataset (typed)
 - `src/page.ts` — renders the page to plain HTML with template strings
 - `src/build.ts` — writes the static site to `dist/` (HTML, open-data JSON, assets)
-- `src/dev.ts` — tiny local server for development only
+- `src/dev.ts` — dev-only server: re-renders on every request and live-reloads the browser over a server-sent-events ping (never deployed)
 - `public/styles.css` — hand-written modern CSS: `light-dark()`, `oklch`, `color-mix()`, native nesting, container queries (size + scroll-state), `:has()`, popover with `@starting-style`, CSS counters
 - `public/app.js` — ~100 lines of vanilla JS for search, filtering, sorting, shareable URL state, and view transitions
 
 ## Develop
 
 ```bash
-bun run dev      # hot-reloading dev server at http://localhost:3000
+bun run dev      # live-reloading dev server at http://localhost:3000
 bun run build    # render the static site to dist/
 bun run preview  # build, then serve dist/ exactly as deployed
 bun run check    # typecheck
 ```
+
+Edit anything in `src/` or `public/` and every open tab reloads itself —
+`bun --hot` re-evaluates the server when source files change, and the dev
+server pings the browser over an SSE stream. No bundler, no plugins.
 
 ## Deploy
 

--- a/src/build.ts
+++ b/src/build.ts
@@ -10,7 +10,7 @@
  *   dist/...                  everything in public/ (styles, script, logos, favicon)
  */
 
-import { cp, mkdir, rm } from 'node:fs/promises';
+import { cp, rm } from 'node:fs/promises';
 import { COMPANIES } from './companies.ts';
 import { renderPage } from './page.ts';
 
@@ -20,9 +20,9 @@ const DIST = new URL('dist/', ROOT);
 const started = performance.now();
 
 await rm(DIST, { recursive: true, force: true });
-await mkdir(new URL('api/', DIST), { recursive: true });
 await cp(new URL('public/', ROOT), DIST, { recursive: true });
 
+// Bun.write creates missing directories (dist/, dist/api/) on its own.
 await Bun.write(new URL('index.html', DIST), renderPage(COMPANIES));
 await Bun.write(
   new URL('api/companies.json', DIST),

--- a/src/dev.ts
+++ b/src/dev.ts
@@ -1,10 +1,17 @@
 /**
  * Local server — NOT used in production (the site deploys as static files).
  *
- *   bun run dev        # render on every request + hot reload (bun --hot)
+ *   bun run dev        # render on every request + live reload in the browser
  *   bun run preview    # serve the built dist/ folder as-is
+ *
+ * Live reload is ~15 lines of platform code, no tooling: `bun --hot`
+ * re-evaluates this module whenever anything in src/ changes, fs.watch
+ * covers public/, and each change pings every open tab over a
+ * server-sent-events stream to refresh itself.
  */
 
+import type { Serve } from 'bun';
+import { watch, type FSWatcher } from 'node:fs';
 import { COMPANIES } from './companies.ts';
 import { renderPage } from './page.ts';
 
@@ -12,31 +19,88 @@ const ROOT = new URL('../', import.meta.url);
 const SERVE_DIST = Bun.argv.includes('--dist');
 const FILES = new URL(SERVE_DIST ? 'dist/' : 'public/', ROOT);
 
+// ---- live reload (dev only) ----
+
+// State survives `bun --hot` re-evaluations by living on globalThis.
+const g = globalThis as typeof globalThis & {
+  devTabs?: Set<ReadableStreamDefaultController>;
+  devGeneration?: number;
+  devWatcher?: FSWatcher;
+};
+
+const tabs = (g.devTabs ??= new Set());
+const reloadTabs = () => {
+  for (const tab of tabs) {
+    try {
+      tab.enqueue('data: reload\n\n');
+    } catch {
+      tabs.delete(tab);
+    }
+  }
+};
+
+// A re-evaluation of this module *is* the "src/ changed" signal.
+g.devGeneration = (g.devGeneration ?? 0) + 1;
+if (g.devGeneration > 1) reloadTabs();
+
+g.devWatcher?.close();
+if (!SERVE_DIST)
+  g.devWatcher = watch(new URL('public/', ROOT), { recursive: true }, reloadTabs);
+
+const RELOADER = `<script>new EventSource('/~dev').onmessage = () => location.reload()</script>`;
+
+const events = (): Response => {
+  let tab: ReadableStreamDefaultController;
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        tabs.add((tab = controller));
+      },
+      cancel() {
+        tabs.delete(tab);
+      }
+    }),
+    { headers: { 'content-type': 'text/event-stream' } }
+  );
+};
+
+// ---- server ----
+
 const html = (body: string) =>
   new Response(body, { headers: { 'content-type': 'text/html; charset=utf-8' } });
+
+const notFound = () => new Response('Not Found', { status: 404 });
+
+/** Unmatched paths are files from public/ (dev) or dist/ (preview). */
+const files = async (req: Request): Promise<Response> => {
+  const pathname = decodeURIComponent(new URL(req.url).pathname);
+  if (pathname.includes('..')) return notFound();
+  const file = Bun.file(new URL(`.${pathname === '/' ? '/index.html' : pathname}`, FILES));
+  return (await file.exists()) ? new Response(file) : notFound();
+};
+
+const STATIC_ROUTES: Serve.Routes<undefined, string> = {
+  // Mirrors the /about -> / redirect configured in vercel.json.
+  '/about': Response.redirect('/', 301),
+  '/*': files
+};
 
 const server = Bun.serve({
   port: Number(Bun.env.PORT ?? 3000),
 
-  routes: {
-    // Mirrors the /about -> / redirect configured in vercel.json.
-    '/about': new Response(null, { status: 301, headers: { location: '/' } })
-  },
-
-  async fetch(req) {
-    const pathname = decodeURIComponent(new URL(req.url).pathname);
-    if (pathname.includes('..')) return new Response('Not Found', { status: 404 });
-
-    if (pathname === '/' && !SERVE_DIST) return html(renderPage(COMPANIES));
-    if (pathname === '/api/companies.json' && !SERVE_DIST)
-      return Response.json(COMPANIES);
-
-    const file = Bun.file(new URL(`.${pathname === '/' ? '/index.html' : pathname}`, FILES));
-    if (await file.exists()) return new Response(file);
-    return new Response('Not Found', { status: 404 });
-  }
+  // Preview serves only what `bun run build` wrote; dev renders the page and
+  // the JSON from source on every request, and adds the live-reload stream.
+  routes: SERVE_DIST
+    ? STATIC_ROUTES
+    : {
+        ...STATIC_ROUTES,
+        '/': () => html(renderPage(COMPANIES).replace('</body>', `${RELOADER}</body>`)),
+        '/api/companies.json': () => Response.json(COMPANIES),
+        '/~dev': events
+      }
 });
 
-console.log(
-  `dsmtech ${SERVE_DIST ? '(dist preview)' : '(dev)'} at ${server.url} — ${COMPANIES.length} companies`
-);
+if (g.devGeneration === 1)
+  console.log(
+    `dsmtech ${SERVE_DIST ? '(dist preview)' : '(dev)'} at ${server.url} — ${COMPANIES.length} companies`
+  );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

A simplification pass over the Bun architecture, with **zero change to the deployed site** — `dist/` builds byte-identical to `main` (verified with `diff -r`).

### `src/dev.ts` — declarative routes + real browser live reload
- Replaced the hand-rolled `fetch` dispatcher with Bun-native `routes`: `Response.redirect('/', 301)` as a static route value, per-path handlers, and one `/*` wildcard for files. Preview (`--dist`) is now just the static routes; dev layers the rendered-from-source routes on top.
- Added genuine live reload with no tooling and no dependencies (~15 lines):
  - `bun --hot` re-evaluating the module *is* the "`src/` changed" signal (state survives on `globalThis`)
  - `fs.watch(public/, { recursive: true })` covers CSS/JS/asset edits
  - open tabs hold an `EventSource('/~dev')` stream (dev-only, injected before `</body>`) and reload themselves on a ping — and since filter/search state lives in the URL, reloads keep your state
- Bun's full-stack HMR (`HTML imports`) was evaluated and deliberately not used: it requires a static `.html` entrypoint, while this page is rendered from `companies.ts` data. SSE-over-`--hot` is the zero-dependency equivalent for a server-rendered page.

### `src/build.ts`
- Dropped the `mkdir` call — `Bun.write` creates parent directories itself.

### `README.md`
- Documents how live reload works (and that the dev server is never deployed).

## Why not more?

Also considered and intentionally rejected, to keep the "ship exactly what you wrote" property:
- `bun build ./index.html` (minify + hash + rewrite): the page is small, Vercel already compresses, and hashed asset names would desync the JSON-LD/OG absolute URLs
- `bun build --compile --target=browser` single-file output: would force inline styles/scripts and break the strict CSP (`style-src 'self'; script-src 'self'`)

## Testing

- `bun run check` clean; `bun run build` output is byte-identical to `main`
- Dev server: `/` (renders + reloader script), `/api/companies.json`, `/about` → 301, CSS/JS/logos content types, 404s, traversal attempts blocked
- Live reload verified end-to-end: edits to `src/companies.ts`, `public/styles.css`, and `public/logos/*` each ping the SSE stream; an edited company name is re-rendered on the next request and reverts cleanly
- Preview server: serves `dist/` only — no reloader markup, `/~dev` 404s, pretty-printed JSON comes from the file

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fbf5d635-db4c-4cb5-b9c3-f77671bbd6c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fbf5d635-db4c-4cb5-b9c3-f77671bbd6c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

